### PR TITLE
Provide type cardinality/instance count

### DIFF
--- a/lib/puppet_x/binford2k/itemize/cli.rb
+++ b/lib/puppet_x/binford2k/itemize/cli.rb
@@ -44,6 +44,11 @@ class Puppet_X::Binford2k::Itemize::Cli
         output << sprintf("    %#{name_width}s | %#{count_width}s\n", name, count)
       end
       output << "\n"
+
+      instances = counts.reduce(0) { |acc, c| acc + c[1] }
+
+      output << sprintf("    %#{name_width}s | %#{count_width}s\n", "Totals: #{counts.count}", instances)
+      output << "\n"
     end
     output
   end


### PR DESCRIPTION
This commit adds counts for the cardinality and aggregate count for each itemized type.

```
Resource usage analysis:
==========================================================
>> types:
                                              group |   1
                                               user |   2
                                          yum::repo |  10
# [...]
                                            package |  49
                                               file | 148
                                               exec |  21


                                         Totals: 31 | 416

>> classes:
                         mysql::service::auto_start |   1
                            mysql::service::systemd |   1
                                     mysql::version |   9
                                              mysql |   4
# [...]
                      mysql::server::mysql_scrubber |   1
                                       mysql::tools |   1
                              mysql::server::metadb |   1

                                        Totals: 175 | 280

>> functions:
                                            boolean |  79
                                            defined |   2
                                               fail |   2
# [...]
                                            sprintf |   3
                                           regsubst |   2
                                             delete |   2

                                         Totals: 16 | 493



```